### PR TITLE
focus: fix Account Prices Preview parameter row

### DIFF
--- a/focus/README.md
+++ b/focus/README.md
@@ -16,10 +16,12 @@ Maps Databricks billing data from Unity Catalog system tables to the [FinOps Ope
 
 | Parameter | Description | Value |
 |-----------|-------------|---------|
-| `:account_prices` | Full path to the prices table. Use this value if you are not in the Account Prices Preview | `system.billing.list_prices` |
-| `:account_prices` | ull path to the prices table. Use this value if you are participating in the Account Prices Preview | `system.billing.list_prices` |
+| `:account_prices` | Full path to the prices table. Use this value if you are **not** in the Account Prices Preview. | `system.billing.list_prices` |
+| `:account_prices` | Full path to the prices table. Use this value if you **are** participating in the Account Prices Preview (AWS and GCP only). | `system.billing.account_prices` |
 
 Set this as a Databricks SQL query parameter or substitute it directly in the query.
+
+> Not sure if you're in the Account Prices Preview? Ask your Databricks account team.
 
 ## Usage
 

--- a/focus/focus_query.sql
+++ b/focus/focus_query.sql
@@ -2,8 +2,9 @@
 -- Compatible with Databricks SQL and Unity Catalog
 -- Specification: https://focus.finops.org/focus-specification/v1-3/
 
--- Usage: Replace :account_prices with your account-level prices table path,
---        e.g. system.billing.list_prices (same table, filtered to your account).
+-- Usage: Replace :account_prices with your account-level prices table path.
+--        If you are not in the Account Prices Preview, use system.billing.list_prices.
+--        If you are in the Account Prices Preview (AWS/GCP only), use system.billing.account_prices.
 WITH pipeline_names AS (
   -- Latest known name per pipeline (system.lakeflow.pipelines is an SCD table)
   SELECT account_id, workspace_id, pipeline_id, name AS pipeline_name


### PR DESCRIPTION
## Summary
- Parameters table in `focus/README.md` had two effectively-identical rows for `:account_prices` (both pointed at `system.billing.list_prices`) and the preview row had a typo ("ull path"). H/T to @stephaniealba for catching this in #focus-private-preview.
- Point the preview row at `system.billing.account_prices` — the Account Prices Preview table (AWS/GCP only).
- Add a one-line callout telling readers to ask their account team if they're unsure whether they're in the preview.
- Align the `focus_query.sql` header comment with the same guidance (the previous "same table, filtered to your account" hint was misleading — the preview table is a different table).

## Test plan
- [ ] Render `focus/README.md` on GitHub — confirm the two rows now show distinct values and the preview-row description has no typo.
- [ ] Eyeball `focus/focus_query.sql` header — confirm the two-line guidance is correct and matches the README.

This pull request and its description were written by Isaac.