### PR TITLE
README: add GCP unified cost to root overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Cloud Infra Costs 
-For Databricks non-serverless compute, total cost of ownership (TCO) information is fragmented between cloud cost reports (e.g., AWS CUR, Azure Cost Mgmt) & Databricks system tables (richer granularity & metadata). While many users are becoming increasingly familiar with Databricks system tables, joining with Azure & AWS cost reports can be cumbersome.
+For Databricks non-serverless compute, total cost of ownership (TCO) information is fragmented between cloud cost reports (e.g., AWS CUR, Azure Cost Mgmt, GCP Billing export) & Databricks system tables (richer granularity & metadata). While many users are becoming increasingly familiar with Databricks system tables, joining with Azure, AWS & GCP cost reports can be cumbersome.
 
 This solution helps automate and simplify this process - with it, users can report on the total infra (VM, networking, storage) and Databricks costs (DBUs) of their classic compute, in unified dashboards.
 
 The FOCUS v1.3 query in [`focus/`](focus/README.md) is listed on the [FinOps Foundation site](https://focus.finops.org/) as a FOCUS v1.3 data generator.
 
-These three pieces can be used independently or in combination:
+These four pieces can be used independently or in combination:
 - [**Azure**](azure/README.md) — unifies Azure Cost Management exports (Actuals, Amortized, FOCUS) with Databricks system tables.
 - [**AWS**](aws/README.md) — unifies AWS CUR with Databricks system tables.
+- [**GCP**](gcp/README.md) — unifies GCP billing exports with Databricks system tables, delivered as a Databricks Asset Bundle (ingestion pipeline, dashboard, and job).
 - [**FOCUS v1.3**](focus/README.md) — vendor-neutral [FinOps Open Cost and Usage Specification](https://focus.finops.org/focus-specification/v1-3/) output from Databricks system tables. Recommended if you want a single, standardized schema across cloud providers.
 
 <img width="1444" height="653" alt="Screenshot 2025-11-05 at 10 58 37 AM" src="https://github.com/user-attachments/assets/611b8cf5-cf23-4c98-84a9-eab3776669fe" />


### PR DESCRIPTION
Updates the root `README.md` to reflect the new GCP support merged in #14.

## Changes
- Added a **GCP** bullet to the modules list, linking to `gcp/README.md` — a Databricks Asset Bundle that ingests GCP billing exports and joins them with Databricks system tables (ingestion pipeline, dashboard, and job).
- Updated "These three pieces" → "These four pieces".
- Included "GCP Billing export" in the intro's cost-report examples and updated "Azure & AWS" → "Azure, AWS & GCP".

This pull request and its description were written by Isaac.